### PR TITLE
convert head and tail injects into a wrapmethod

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.9-SNAPSHOT'
+    id 'fabric-loom' version '1.10-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip

--- a/src/main/java/com/aeroshide/debugguiscale/mixins/DebugHudMixin.java
+++ b/src/main/java/com/aeroshide/debugguiscale/mixins/DebugHudMixin.java
@@ -1,13 +1,12 @@
 package com.aeroshide.debugguiscale.mixins;
 
-import com.aeroshide.debugguiscale.DebugguiscaleClient;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.DebugHud;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
 
@@ -15,20 +14,16 @@ import static com.aeroshide.debugguiscale.DebugguiscaleClient.scale;
 
 @Mixin(DebugHud.class)
 abstract class DebugHudMixin {
-
-    @Inject(method = "drawText", at = @At("HEAD"))
-    private void beforeTextRendering(DrawContext context, List<String> text, boolean left, CallbackInfo ci) {
+    @WrapMethod(method = "drawText")
+    private void wrapTextRendering(DrawContext context, List<String> text, boolean left, Operation<Void> original) {
         context.getMatrices().push();
         context.getMatrices().scale(scale.floatValue(), scale.floatValue(), 0.0F);
+        original.call(context, text, left);
+        context.getMatrices().pop();
     }
 
     @ModifyExpressionValue(method = "drawText", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;getScaledWindowWidth()I"))
     private int getReadWidth(int original) {
         return (int) (original / scale);
-    }
-
-    @Inject(method = "drawText", at = @At("TAIL"))
-    private void afterTextRendering(DrawContext context, List<String> text, boolean left, CallbackInfo ci) {
-        context.getMatrices().pop();
     }
 }


### PR DESCRIPTION
This PR converts the head and tail injections to drawText into a WrapMethod. This is important in the case any mod decides to cancel the debug hud rendering after this mod has already pushed and scaled, leading to matrices never getting popped afterwards. With a WrapMethod, even if another mod cancels the method, this pop will still run.

Also, Loom 1.9 snapshot now requires a newer gradle version, so I bumped both. Fabric Example Mod uses 8.12.1 but I use 8.13 for my mods and it works with no issues so I went with that.